### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,6 @@
 name: Pylint
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/secwexen/cyber-threat-playbook/security/code-scanning/1](https://github.com/secwexen/cyber-threat-playbook/security/code-scanning/1)

In general, fix this by adding an explicit `permissions` block to the workflow (at the top level or per job) that grants only the minimal scopes needed. For this workflow, which just checks out code and runs `pylint`, only read access to repository contents is required.

The best minimal fix without changing existing functionality is to add a top-level `permissions` section right after the `name` (or before `jobs`) that sets `contents: read`. This will apply to all jobs (here there is only `build`) and constrain the `GITHUB_TOKEN` accordingly. No additional imports or tooling changes are required.

Concretely, in `.github/workflows/pylint.yml`, add:

```yaml
permissions:
  contents: read
```

between the `name: Pylint` line and the `on: [push]` line. All other lines remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
