### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/secwexen/security-playbooks/security/code-scanning/2](https://github.com/secwexen/security-playbooks/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here (without changing behavior) is to set workflow-level permissions to:

- `contents: read`

This is sufficient for `actions/checkout` and does not grant unnecessary write scopes.  
Edit **`.github/workflows/docker-image.yml`** by inserting the `permissions` block between the trigger (`on:`) and `jobs:` sections.

No imports, methods, or additional definitions are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
