### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/secwexen/security-playbooks/security/code-scanning/3](https://github.com/secwexen/security-playbooks/security/code-scanning/3)

Add an explicit `permissions` block to `.github/workflows/makefile.yml` at the workflow root so it applies to all jobs (including `build`) unless overridden.  
For this CI workflow, the minimal and correct permission is:

- `contents: read`

This preserves existing functionality (checkout and build/test commands) while preventing unintended write-capable token usage if defaults are broad now or in the future.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
